### PR TITLE
Allowed study entry values to be list of simple fields

### DIFF
--- a/metadata_registration_api/api/api_utils.py
+++ b/metadata_registration_api/api/api_utils.py
@@ -64,10 +64,13 @@ class StudyEntry:
         if isinstance(self.value, list):
             my_list = []
             for entry in self.value:
-                my_list_2 = {}
-                for item in entry.value:
-                    my_list_2[item.name] = item.form_format()
-                my_list.append({entry.name: my_list_2})
+                if isinstance(entry.value, list):
+                    my_list_2 = {}
+                    for item in entry.value:
+                        my_list_2[item.name] = item.form_format()
+                    my_list.append({entry.name: my_list_2})
+                else:
+                    my_list.append(entry.value)
             return my_list
         else:
             return self.value


### PR DESCRIPTION
For posting Study entries, the following formats are working:
```python
entry: {
     prop: 123
     value: abc
}

entry: {
      prop: 123
      value: [{prop: 123, value: [{}, ...]}, {prop: 123, value: [{}, ...]}]
}
```
But the following intermediate format is causing issues (fixed in this PR):
```python
entry: {
      prop: 123
      value: [{prop: 123, value: abc}, {prop: 123, value: abc}]
}
```

In the Forms world, this allows having `FieldList` composed of `StringField` for example.