### PR TITLE
Restructure conversion between api and form format.

### DIFF
--- a/test/test_api_util.py
+++ b/test/test_api_util.py
@@ -1,12 +1,12 @@
 import unittest
 
 from metadata_registration_api.api import api_utils
+from metadata_registration_api.api.api_utils import FormatConverter
 
 
-class TestAPI_Util(unittest.TestCase):
+class TestAPIUtil(unittest.TestCase):
 
     def test_meta_information_empty_change_log(self):
-
         state = "Initial test state"
 
         m = api_utils.MetaInformation(state=state)
@@ -16,28 +16,271 @@ class TestAPI_Util(unittest.TestCase):
 
         self.assertEqual(expected_json, actual_json)
 
-    def test_study_entry_form_format(self):
-        mapper = {"1": "fields", "2": "datafile", "3": "path", "4": "method", "5": "name", "6": "datafiles"}
 
-        entities = [
-            {"prop": "5", "value": "test name"},
-            {"prop": "6",
-                "value": [
-                    {"prop": "2", "value": [{"prop": "3", "value": "/pstore/"}, {"prop": "4", "value": "count"}]},
-                    {"prop": "2", "value": [{"prop": "3", "value": "/pstore/"}, {"prop": "4", "value": "count"}]},
-                ]
-             }
+class TestFormatConverter(unittest.TestCase):
+
+    def test_api_to_form_format_case_1(self):
+        """Simple value"""
+        mapper = {"1": "username"}
+
+        input_format = [
+            {
+                "prop": "1",
+                "value": "Edward"
+            }
         ]
 
-        actual = api_utils.json_input_to_form_format(entities, mapper, key_name="prop", value_name="value")
+        expected_form_format = {"username": "Edward"}
 
-        expected = {
-            "name": "test name", "datafiles":
-                [
-                    {"datafile": {"path": "/pstore/", "method": "count"}},
-                    {"datafile": {"path": "/pstore/", "method": "count"}}
+        c = FormatConverter(key_name="prop", value_name="value", mapper=mapper)
+        actual_form_format = c.add_api_format(input_format).get_form_format()
+
+        self.assertEqual(expected_form_format, actual_form_format)
+
+    def test_api_to_form_format_case_2(self):
+        """List of simple values"""
+        mapper = {"1": "username"}
+
+        input_format = [
+            {
+                "prop": "1",
+                "value": ["Edward", "Annie"]
+            }
+        ]
+
+        expected_form_format = {"username": ["Edward", "Annie"]}
+
+        c = FormatConverter(key_name="prop", value_name="value", mapper=mapper)
+        actual_form_format = c.add_api_format(input_format).get_form_format()
+
+        self.assertEqual(expected_form_format, actual_form_format)
+
+    def test_api_to_form_format_case_3(self):
+        """A nested form field. Only one form field is accepted"""
+        mapper = {"1": "storage", "2": "location", "3": "number_of_files"}
+
+        input_format = [
+            {
+                "prop": "1",
+                "value": [
+                    {"prop": "2", "value": "C:/Documents"},
+                    {"prop": "3", "value": 1000}
                 ]
+            }
+        ]
+
+        expected_form_format = {
+            "storage": {
+                "location": "C:/Documents", "number_of_files": 1000
+            }
         }
 
-        self.assertEqual(expected, actual)
+        c = FormatConverter(key_name="prop", value_name="value", mapper=mapper)
+        actual_form_format = c.add_api_format(input_format).get_form_format()
 
+        self.assertEqual(expected_form_format, actual_form_format)
+
+    def test_api_to_form_format_case_4(self):
+        """List of nested form fields. Each form field is incorporated into a list"""
+        mapper = {"1": "contacts", "3": "name", "4": "phone"}
+
+        input_format = [
+            {
+                "prop": "1",
+                "value": [
+                    [
+                        {"prop": "3", "value": "Edward"},
+                        {"prop": "4", "value": "903 367 2072"}
+                    ],
+                    [
+                        {"prop": "3", "value": "Annie"},
+                        {"prop": "4", "value": "731 222 8842"}
+                    ]
+                ],
+            }
+        ]
+
+        expected_form_format = {
+            "contacts": [
+                {
+                    "name": "Edward", "phone": "903 367 2072"
+                },
+                {
+                    "name": "Annie", "phone": "731 222 8842"
+                }
+            ]
+        }
+
+        c = FormatConverter(key_name="prop", value_name="value", mapper=mapper)
+        actual_form_format = c.add_api_format(input_format).get_form_format()
+
+        self.assertEqual(expected_form_format, actual_form_format)
+
+    def test_api_to_api_format_case_1(self):
+        """Simple value"""
+        mapper = {"1": "username"}
+
+        input_format = [
+            {
+                "prop": "1",
+                "value": "Edward"
+            }
+        ]
+
+        c = FormatConverter(key_name="prop", value_name="value", mapper=mapper)
+        reconstructed_api_format = c.add_api_format(input_format).get_api_format()
+
+        self.assertEqual(input_format, reconstructed_api_format)
+
+    def test_api_to_api_format_case_2(self):
+        """List of simple values"""
+        mapper = {"1": "username"}
+
+        input_format = [
+            {
+                "prop": "1",
+                "value": ["Edward", "Annie"]
+            }
+        ]
+
+        c = FormatConverter(key_name="prop", value_name="value", mapper=mapper)
+        reconstructed_api_format = c.add_api_format(input_format).get_api_format()
+
+        self.assertEqual(input_format, reconstructed_api_format)
+
+    def test_api_to_api_format_case_3(self):
+        """A nested form field. Only one form field is accepted"""
+        mapper = {"1": "storage", "2": "location", "3": "number_of_files"}
+
+        input_format = [
+            {
+                "prop": "1",
+                "value": [
+                    {"prop": "2", "value": "C:/Documents"},
+                    {"prop": "3", "value": 1000}
+                ]
+            }
+        ]
+
+        c = FormatConverter(key_name="prop", value_name="value", mapper=mapper)
+        reconstructed_api_format = c.add_api_format(input_format).get_api_format()
+
+        self.assertEqual(input_format, reconstructed_api_format)
+
+    def test_api_to_api_format_case_4(self):
+        """List of nested form fields. Each form field is incorporated into a list"""
+        mapper = {"1": "contacts", "3": "name", "4": "phone"}
+
+        input_format = [
+            {
+                "prop": "1",
+                "value": [
+                    [
+                        {"prop": "3", "value": "Edward"},
+                        {"prop": "4", "value": "903 367 2072"}
+                    ],
+                    [
+                        {"prop": "3", "value": "Annie"},
+                        {"prop": "4", "value": "731 222 8842"}
+                    ]
+                ],
+            }
+        ]
+
+        c = FormatConverter(key_name="prop", value_name="value", mapper=mapper)
+        reconstructed_input_format = c.add_api_format(input_format).get_api_format()
+
+        self.assertEqual(input_format, reconstructed_input_format)
+
+    def test_form_to_api_form_format_case_1(self):
+        mapper = {"username": "1"}
+
+        form_format = {"username": "Edward"}
+
+        expected_api_format = [
+            {
+                "prop": "1",
+                "value": "Edward"
+            }
+        ]
+
+        c = FormatConverter(key_name="prop", value_name="value", mapper=mapper)
+        actual_api_format = c.add_form_format(form_format).get_api_format()
+
+        self.assertEqual(expected_api_format, actual_api_format)
+
+    def test_form_to_api_format_case_2(self):
+        mapper = {"username": "1"}
+
+        form_format = {"username": ["Edward", "Annie"]}
+
+        expected_api_format = [
+            {
+                "prop": "1",
+                "value": ["Edward", "Annie"]
+            }
+        ]
+
+        c = FormatConverter(key_name="prop", value_name="value", mapper=mapper)
+        actual_api_format = c.add_form_format(form_format).get_api_format()
+
+        self.assertEqual(expected_api_format, actual_api_format)
+
+    def test_form_to_api_format_case_3(self):
+        mapper = {"storage": "1", "location": "2", "number_of_files": "3"}
+
+        form_format = {
+            "storage": {
+                "location": "C:/Documents", "number_of_files": 1000
+            }
+        }
+
+        expected_api_format = [
+            {
+                "prop": "1",
+                "value": [
+                    {"prop": "2", "value": "C:/Documents"},
+                    {"prop": "3", "value": 1000}
+                ]
+            }
+        ]
+
+        c = FormatConverter(key_name="prop", value_name="value", mapper=mapper)
+        actual_api_format = c.add_form_format(form_format).get_api_format()
+
+        self.assertEqual(expected_api_format, actual_api_format)
+
+    def test_form_to_api_format_case_4(self):
+        mapper = {"contacts": "1", "name": "3", "phone": "4"}
+
+        form_format = {
+            "contacts": [
+                {
+                    "name": "Edward", "phone": "903 367 2072"
+                },
+                {
+                    "name": "Annie", "phone": "731 222 8842"
+                }
+            ]
+        }
+
+        actual_api_format = [
+            {
+                "prop": "1",
+                "value": [
+                    [
+                        {"prop": "3", "value": "Edward"},
+                        {"prop": "4", "value": "903 367 2072"}
+                    ],
+                    [
+                        {"prop": "3", "value": "Annie"},
+                        {"prop": "4", "value": "731 222 8842"}
+                    ]
+                ],
+            }
+        ]
+
+        c = FormatConverter(key_name="prop", value_name="value", mapper=mapper)
+        expected_api_format = c.add_form_format(form_format).get_api_format()
+
+        self.assertEqual(expected_api_format, actual_api_format)


### PR DESCRIPTION
See issue #6 for problem description

FormConverter is the entry point. It contains the following four functions to convert in both directions:
  - add_api_format()
  - add_form_format()
  - get_api_format()
  - get_form_format()

 Features:
  - Conversion in both directions
  - Supports four types for values
    - primitives
    - list of primitives
    - sub-form
    - list of sub-forms
  - Chain a 'get_xx' function after an 'add_xx' function.
  - A map must be provided for the mapping between property id and property name.
  - Code is 100% tested.

closes #6 