### PR TITLE
Used strict_slashes parameter to clean swagger doc

### DIFF
--- a/metadata_registration_api/api/api_ctrl_voc.py
+++ b/metadata_registration_api/api/api_ctrl_voc.py
@@ -99,8 +99,7 @@ class ApiControlledVocabulary(Resource):
             return {"message": "Delete all entries"}
 
 
-@api.route("/id/<id>")
-@api.route("/id/<id>/")
+@api.route("/id/<id>", strict_slashes=False)
 @api.param("id", "The property identifier")
 class ApiControlledVocabulary(Resource):
     _delete_parser = reqparse.RequestParser()

--- a/metadata_registration_api/api/api_form.py
+++ b/metadata_registration_api/api/api_form.py
@@ -157,8 +157,7 @@ class ApiForm(Resource):
             return {"message": f"Delete all entries"}
 
 
-@api.route("/id/<id>")
-@api.route("/id/<id>/")
+@api.route("/id/<id>", strict_slashes=False)
 @api.param("id", "The property identifier")
 class ApiForm(Resource):
     _delete_parser = reqparse.RequestParser()

--- a/metadata_registration_api/api/api_props.py
+++ b/metadata_registration_api/api/api_props.py
@@ -132,8 +132,7 @@ class ApiProperties(Resource):
             return {"message": "Delete all entries"}
 
 
-@api.route("/id/<id>")
-@api.route("/id/<id>/")
+@api.route("/id/<id>", strict_slashes=False)
 @api.param("id", "The property identifier")
 class ApiProperty(Resource):
     _delete_parser = reqparse.RequestParser()

--- a/metadata_registration_api/api/api_study.py
+++ b/metadata_registration_api/api/api_study.py
@@ -193,8 +193,7 @@ class ApiStudy(Resource):
         return {"message": "Delete all entries"}
 
 
-@api.route("/id/<id>")
-@api.route("/id/<id>/")
+@api.route("/id/<id>", strict_slashes=False)
 @api.param("id", "The property identifier")
 class ApiStudy(Resource):
     _delete_parser = reqparse.RequestParser()
@@ -353,8 +352,7 @@ class ApiStudyDataset(Resource):
         return {"message": message, "uuid": dataset_uuid}, 201
 
 
-@api.route("/id/<study_id>/datasets/id/<dataset_uuid>")
-@api.route("/id/<study_id>/datasets/id/<dataset_uuid>/")
+@api.route("/id/<study_id>/datasets/id/<dataset_uuid>", strict_slashes=False)
 @api.param("study_id", "The study identifier")
 @api.param("dataset_uuid", "The dataset identifier")
 class ApiStudyDataset(Resource):
@@ -510,8 +508,7 @@ class ApiStudyPE(Resource):
         return {"message": message, "uuid": pe_uuid}, 201
 
 
-@api.route("/id/<study_id>/datasets/id/<dataset_uuid>/pes/id/<pe_uuid>")
-@api.route("/id/<study_id>/datasets/id/<dataset_uuid>/pes/id/<pe_uuid>/")
+@api.route("/id/<study_id>/datasets/id/<dataset_uuid>/pes/id/<pe_uuid>", strict_slashes=False)
 @api.param("study_id", "The study identifier")
 @api.param("dataset_uuid", "The dataset identifier")
 @api.param("pe_uuid", "The processing event identifier")

--- a/metadata_registration_api/api/api_user.py
+++ b/metadata_registration_api/api/api_user.py
@@ -130,8 +130,7 @@ class ApiUser(Resource):
             return {"message": "Delete all entries"}
 
 
-@api.route("/id/<id>")
-@api.route("/id/<id>/")
+@api.route("/id/<id>", strict_slashes=False)
 @api.param("id", "The property identifier")
 class ApiUser(Resource):
     _delete_parser = reqparse.RequestParser()


### PR DESCRIPTION
Replaced all the following routes definitions:
```python
@api.route("/xxx/<id>")
@api.route("/xxx/<id>/")
```
by:
```python
@api.route("/xxx/<id>", strict_slashes=False)
```
In order to remove duplication in the swagger UI for the GET, PUT and DELETE methods