### PR TITLE
Updated API class names to avoid ID duplication

### DIFF
--- a/metadata_registration_api/api/api_ctrl_voc.py
+++ b/metadata_registration_api/api/api_ctrl_voc.py
@@ -101,7 +101,7 @@ class ApiControlledVocabulary(Resource):
 
 @api.route("/id/<id>", strict_slashes=False)
 @api.param("id", "The property identifier")
-class ApiControlledVocabulary(Resource):
+class ApiControlledVocabularyId(Resource):
     _delete_parser = reqparse.RequestParser()
     _delete_parser.add_argument("complete",
                                type=inputs.boolean,

--- a/metadata_registration_api/api/api_form.py
+++ b/metadata_registration_api/api/api_form.py
@@ -159,7 +159,7 @@ class ApiForm(Resource):
 
 @api.route("/id/<id>", strict_slashes=False)
 @api.param("id", "The property identifier")
-class ApiForm(Resource):
+class ApiFormId(Resource):
     _delete_parser = reqparse.RequestParser()
     _delete_parser.add_argument("complete",
                                type=inputs.boolean,

--- a/metadata_registration_api/api/api_props.py
+++ b/metadata_registration_api/api/api_props.py
@@ -134,7 +134,7 @@ class ApiProperties(Resource):
 
 @api.route("/id/<id>", strict_slashes=False)
 @api.param("id", "The property identifier")
-class ApiProperty(Resource):
+class ApiPropertyId(Resource):
     _delete_parser = reqparse.RequestParser()
     _delete_parser.add_argument("complete",
                                type=inputs.boolean,

--- a/metadata_registration_api/api/api_study.py
+++ b/metadata_registration_api/api/api_study.py
@@ -195,7 +195,7 @@ class ApiStudy(Resource):
 
 @api.route("/id/<id>", strict_slashes=False)
 @api.param("id", "The property identifier")
-class ApiStudy(Resource):
+class ApiStudyId(Resource):
     _delete_parser = reqparse.RequestParser()
     _delete_parser.add_argument("complete",
                                type=inputs.boolean,
@@ -355,7 +355,7 @@ class ApiStudyDataset(Resource):
 @api.route("/id/<study_id>/datasets/id/<dataset_uuid>", strict_slashes=False)
 @api.param("study_id", "The study identifier")
 @api.param("dataset_uuid", "The dataset identifier")
-class ApiStudyDataset(Resource):
+class ApiStudyDatasetId(Resource):
 
     # @token_required
     def get(self, study_id, dataset_uuid):
@@ -512,7 +512,7 @@ class ApiStudyPE(Resource):
 @api.param("study_id", "The study identifier")
 @api.param("dataset_uuid", "The dataset identifier")
 @api.param("pe_uuid", "The processing event identifier")
-class ApiStudyPE(Resource):
+class ApiStudyPEId(Resource):
 
     # @token_required
     def get(self, study_id, dataset_uuid, pe_uuid):

--- a/metadata_registration_api/api/api_user.py
+++ b/metadata_registration_api/api/api_user.py
@@ -132,7 +132,7 @@ class ApiUser(Resource):
 
 @api.route("/id/<id>", strict_slashes=False)
 @api.param("id", "The property identifier")
-class ApiUser(Resource):
+class ApiUserId(Resource):
     _delete_parser = reqparse.RequestParser()
     _delete_parser.add_argument("complete",
                                type=inputs.boolean,


### PR DESCRIPTION
Some swagger operations share the same ids causing multiple collapse objects on the swagger page to open/clause at the same time.

As mentioned in the doc here: https://flask-restx.readthedocs.io/en/latest/swagger.html

> If not specified, a default operationId is provided with the following pattern:
>  `{{verb}}_{{resource class name | camelCase2dashes }}`